### PR TITLE
fix: wperf list errors when no Predefined Groups of metrics is returned

### DIFF
--- a/WindowsPerfGUI/SDK/WperfOutputs/WperfList.cs
+++ b/WindowsPerfGUI/SDK/WperfOutputs/WperfList.cs
@@ -31,7 +31,6 @@
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection.Emit;
 
 namespace WindowsPerfGUI.SDK.WperfOutputs
 {
@@ -101,7 +100,7 @@ namespace WindowsPerfGUI.SDK.WperfOutputs
         public List<PredefinedMetric> PredefinedMetrics { get; set; }
 
         [JsonProperty("Predefined_Groups_of_Metrics")]
-        public List<PredefinedGroupsOfMetric> PredefinedGroupsOfMetrics { get; set; }
+        public List<PredefinedGroupsOfMetric>? PredefinedGroupsOfMetrics { get; set; }
 
 
         public List<PredefinedMetricAndGroupOfMetrics> PredefinedMetricsAndGroupsOfMetrics
@@ -117,6 +116,7 @@ namespace WindowsPerfGUI.SDK.WperfOutputs
                         Metric = predefinedMetric.Metric
                     });
                 }
+                if (PredefinedGroupsOfMetrics == null) return metricsAndGroupsOfMetrics;
                 foreach (var predefinedGroupOfMetric in PredefinedGroupsOfMetrics)
                 {
                     metricsAndGroupsOfMetrics.Add(new PredefinedMetricAndGroupOfMetrics()
@@ -128,7 +128,7 @@ namespace WindowsPerfGUI.SDK.WperfOutputs
                 return metricsAndGroupsOfMetrics;
             }
         }
-           
+
         public class PredefinedMetricAndGroupOfMetrics
         {
             public string Metric { get; set; }


### PR DESCRIPTION
This pull request includes changes to the `WindowsPerfGUI/SDK/WperfOutputs/WperfList.cs` file, focusing on improving code quality and handling potential null values in the `PredefinedGroupsOfMetrics` property.

Code quality improvements:

* [`WindowsPerfGUI/SDK/WperfOutputs/WperfList.cs`](diffhunk://#diff-347b2e4de6017e48f9c343993f6773126e19bb591dbde655bf7dc6c0b22dbab0L34): Removed an unused `using System.Reflection.Emit` directive to clean up the code.

Null handling improvements:

* [`WindowsPerfGUI/SDK/WperfOutputs/WperfList.cs`](diffhunk://#diff-347b2e4de6017e48f9c343993f6773126e19bb591dbde655bf7dc6c0b22dbab0L104-R103): Made the `PredefinedGroupsOfMetrics` property nullable to handle cases where it might not be set.
* [`WindowsPerfGUI/SDK/WperfOutputs/WperfList.cs`](diffhunk://#diff-347b2e4de6017e48f9c343993f6773126e19bb591dbde655bf7dc6c0b22dbab0R119): Added a null check for `PredefinedGroupsOfMetrics` before iterating over it to prevent potential null reference exceptions.