### PR TITLE
feat: use WINDOWSPERF_PATH env variable as default value for wperf path

### DIFF
--- a/WindowsPerfGUI/Options/WPerfOptions.cs
+++ b/WindowsPerfGUI/Options/WPerfOptions.cs
@@ -48,7 +48,10 @@ namespace WindowsPerfGUI.Options
         [DisplayName("WindowsPerf path")]
         [Description("The path for the wperf.exe file")]
         [DefaultValue(true)]
-        public string WperfPath { get; set; } = "wperf.exe";
+        public string WperfPath { get; set; } =
+            !string.IsNullOrEmpty(WperfDefaults.DefaultWperfPath)
+                ? WperfDefaults.DefaultWperfPath + "\\wperf.exe"
+                : "wperf.exe";
         public bool WperfVersionCheckIgnore { get; set; } = false;
         public bool IsWperfInitialized { get; set; } = false;
         public bool HasSPESupport { get; set; } = false;

--- a/WindowsPerfGUI/Options/WPerfPath.xaml
+++ b/WindowsPerfGUI/Options/WPerfPath.xaml
@@ -32,6 +32,13 @@
                     Width="Auto"
                     Margin="5" />
 
+                <TextBlock
+                    x:Name="WperfDefaultPathNotice"
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Margin="5"
+                    FontSize="12"
+                    Visibility="Collapsed" />
                 <Button
                     x:Name="ValidateButton"
                     Grid.Row="1"

--- a/WindowsPerfGUI/Options/WPerfPath.xaml.cs
+++ b/WindowsPerfGUI/Options/WPerfPath.xaml.cs
@@ -53,6 +53,13 @@ namespace WindowsPerfGUI.Options
         public void Initialize()
         {
             PathInput.Text = WPerfOptions.Instance.WperfPath;
+
+            if (!string.IsNullOrEmpty(WperfDefaults.DefaultWperfPath))
+            {
+                WperfDefaultPathNotice.Text =
+                    $"WINDOWSPERF_PATH=\"{WperfDefaults.DefaultWperfPath}\"";
+                WperfDefaultPathNotice.Visibility = Visibility.Visible;
+            }
             if (
                 WPerfOptions.Instance.IsWperfInitialized
                 && WPerfOptions.Instance.WperfCurrentVersion != null

--- a/WindowsPerfGUI/Utils/WperfDefaults.cs
+++ b/WindowsPerfGUI/Utils/WperfDefaults.cs
@@ -39,9 +39,14 @@ namespace WindowsPerfGUI.Utils
         public static string? Frequency;
         public static int? TotalGPCNum;
 
-        public static string DefaultWPASearchDir = Environment.GetEnvironmentVariable(
-            "WPA_ADDITIONAL_SEARCH_DIRECTORIES"
-        ) ?? "C:\\Program Files (x86)\\Windows Kits\\10\\Windows Performance Toolkit\\CustomDataSources";
 #nullable disable
+
+        public static string DefaultWPASearchDir =
+            Environment.GetEnvironmentVariable("WPA_ADDITIONAL_SEARCH_DIRECTORIES")
+            ?? "C:\\Program Files (x86)\\Windows Kits\\10\\Windows Performance Toolkit\\CustomDataSources";
+
+        public static string DefaultWperfPath = Environment.GetEnvironmentVariable(
+            "WINDOWSPERF_PATH"
+        );
     }
 }


### PR DESCRIPTION
# Introduction

Use `WINDOWSPERF_PATH` as a defaut value for the `wperf` path input in settings.
If the env variable is set, it will be shown in the UI.

## In this patch:
feat: use WINDOWSPERF_PATH env variable as default value for wperf path

# Testing

![image](https://github.com/user-attachments/assets/54a83fb5-d984-4513-9c2f-c2746a5e53e2)


closes #4 
