### PR TITLE
feat: use checkbox + directory select in wperf path settings

### DIFF
--- a/WindowsPerfGUI/Options/WPerfOptions.cs
+++ b/WindowsPerfGUI/Options/WPerfOptions.cs
@@ -30,6 +30,7 @@
 
 
 using System.ComponentModel;
+using System.IO;
 using System.Runtime.InteropServices;
 using WindowsPerfGUI.SDK.WperfOutputs;
 using WindowsPerfGUI.Utils;
@@ -50,7 +51,7 @@ namespace WindowsPerfGUI.Options
         [DefaultValue(true)]
         public string WperfPath { get; set; } =
             !string.IsNullOrEmpty(WperfDefaults.DefaultWperfPath)
-                ? WperfDefaults.DefaultWperfPath + "\\wperf.exe"
+                ? Path.Combine(WperfDefaults.DefaultWperfPath, "wperf.exe")
                 : "wperf.exe";
         public bool WperfVersionCheckIgnore { get; set; } = false;
         public bool IsWperfInitialized { get; set; } = false;

--- a/WindowsPerfGUI/Options/WPerfOptions.cs
+++ b/WindowsPerfGUI/Options/WPerfOptions.cs
@@ -56,6 +56,8 @@ namespace WindowsPerfGUI.Options
         public bool IsWperfInitialized { get; set; } = false;
         public bool HasSPESupport { get; set; } = false;
         public bool UseDefaultSearchDirectory { get; set; } = true;
+        public bool UseDefaultWperfLocation { get; set; } =
+            !string.IsNullOrEmpty(WperfDefaults.DefaultWperfPath);
         public string WPAPluginSearchDirectory { get; set; }
         public WperfVersion WperfCurrentVersion { get; set; }
         public WperfList WperfList { get; set; }

--- a/WindowsPerfGUI/Options/WPerfPath.xaml
+++ b/WindowsPerfGUI/Options/WPerfPath.xaml
@@ -20,33 +20,44 @@
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-
                 <Label
                     Grid.Row="0"
                     Grid.Column="0"
                     Content="{x:Static locals:OptionsPageLanguagePack.WperfPathPlaceholder}" />
-                <TextBox
-                    x:Name="PathInput"
+                <Grid
                     Grid.Row="0"
                     Grid.Column="1"
-                    Width="Auto"
-                    Margin="5" />
-
-                <TextBlock
-                    x:Name="WperfDefaultPathNotice"
-                    Grid.Row="1"
-                    Grid.Column="1"
-                    Margin="5"
-                    FontSize="12"
-                    Visibility="Collapsed" />
+                    Margin="5">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="100" />
+                    </Grid.ColumnDefinitions>
+                    <TextBox x:Name="PathInput" Width="Auto" />
+                    <Button
+                        Name="SelectDirectoryButton"
+                        Grid.Column="1"
+                        Margin="5,0,0,0"
+                        Click="SelectDirectory_Click"
+                        Content="Select" />
+                </Grid>
                 <Button
                     x:Name="ValidateButton"
                     Grid.Row="1"
-                    Grid.Column="0"
                     Margin="5"
                     Click="ValidateButton_Click"
                     Content="{x:Static locals:OptionsPageLanguagePack.Validate}" />
-
+                <CheckBox
+                    x:Name="WperfDefaultPathCheckbox"
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    Click="WperfDefaultPathCheckbox_Click"
+                    Visibility="Collapsed">
+                    <!--  This allows using underscores in CheckBox label  -->
+                    <CheckBox.Content>
+                        <TextBlock x:Name="WperfDefaultPathCheckboxLabel" />
+                    </CheckBox.Content>
+                </CheckBox>
                 <TextBlock
                     x:Name="PlaceholderLabel"
                     Grid.Row="2"

--- a/WindowsPerfGUI/Options/WPerfPath.xaml.cs
+++ b/WindowsPerfGUI/Options/WPerfPath.xaml.cs
@@ -28,6 +28,7 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -59,7 +60,7 @@ namespace WindowsPerfGUI.Options
             {
                 WperfDefaultPathCheckbox.IsChecked = true;
                 PathInput.IsEnabled = false;
-                PathInput.Text = WperfDefaults.DefaultWperfPath + "\\wperf.exe";
+                PathInput.Text = Path.Combine(WperfDefaults.DefaultWperfPath, "wperf.exe");
                 SelectDirectoryButton.IsEnabled = false;
             }
             if (!string.IsNullOrEmpty(WperfDefaults.DefaultWperfPath))
@@ -203,7 +204,7 @@ namespace WindowsPerfGUI.Options
             SelectDirectoryButton.IsEnabled = !newValue;
             if (newValue)
             {
-                PathInput.Text = WperfDefaults.DefaultWperfPath + "\\wperf.exe";
+                PathInput.Text = Path.Combine(WperfDefaults.DefaultWperfPath, "wperf.exe");
             }
 
             WPerfOptions.Instance.UseDefaultWperfLocation = newValue;

--- a/WindowsPerfGUI/Options/WPerfPath.xaml.cs
+++ b/WindowsPerfGUI/Options/WPerfPath.xaml.cs
@@ -31,6 +31,7 @@
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Forms;
 using WindowsPerfGUI.Resources.Locals;
 using WindowsPerfGUI.SDK;
 using WindowsPerfGUI.SDK.WperfOutputs;
@@ -41,7 +42,7 @@ namespace WindowsPerfGUI.Options
     /// <summary>
     /// Interaction logic for WPerfOptions.xaml
     /// </summary>
-    public partial class WPerfPath : UserControl
+    public partial class WPerfPath : System.Windows.Controls.UserControl
     {
         public WPerfPath()
         {
@@ -54,11 +55,18 @@ namespace WindowsPerfGUI.Options
         {
             PathInput.Text = WPerfOptions.Instance.WperfPath;
 
+            if (WPerfOptions.Instance.UseDefaultWperfLocation)
+            {
+                WperfDefaultPathCheckbox.IsChecked = true;
+                PathInput.IsEnabled = false;
+                PathInput.Text = WperfDefaults.DefaultWperfPath + "\\wperf.exe";
+                SelectDirectoryButton.IsEnabled = false;
+            }
             if (!string.IsNullOrEmpty(WperfDefaults.DefaultWperfPath))
             {
-                WperfDefaultPathNotice.Text =
+                WperfDefaultPathCheckboxLabel.Text =
                     $"WINDOWSPERF_PATH=\"{WperfDefaults.DefaultWperfPath}\"";
-                WperfDefaultPathNotice.Visibility = Visibility.Visible;
+                WperfDefaultPathCheckbox.Visibility = Visibility.Visible;
             }
             if (
                 WPerfOptions.Instance.IsWperfInitialized
@@ -118,7 +126,7 @@ namespace WindowsPerfGUI.Options
 
         private void ClearMainStack()
         {
-            MainStack.Children.RemoveRange(OFFSET_ROW + 1, MainStack.Children.Count - OFFSET_ROW);
+            MainStack.Children.RemoveRange(OFFSET_ROW + 2, MainStack.Children.Count - OFFSET_ROW);
         }
 
         private void SetWperfVersion(WperfVersion wperfVersion, bool shouldForce = false)
@@ -185,6 +193,34 @@ namespace WindowsPerfGUI.Options
                 || WPerfVersionCheckIgnore.IsChecked == false;
             WPerfOptions.Instance.WperfVersionCheckIgnore = !shouldEnforceVersionCheck;
             WPerfOptions.Instance.Save();
+        }
+
+        private void WperfDefaultPathCheckbox_Click(object sender, RoutedEventArgs e)
+        {
+            bool newValue = !WPerfOptions.Instance.UseDefaultWperfLocation;
+
+            PathInput.IsEnabled = !newValue;
+            SelectDirectoryButton.IsEnabled = !newValue;
+            if (newValue)
+            {
+                PathInput.Text = WperfDefaults.DefaultWperfPath + "\\wperf.exe";
+            }
+
+            WPerfOptions.Instance.UseDefaultWperfLocation = newValue;
+        }
+
+        private void SelectDirectory_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            using var fbd = new FolderBrowserDialog()
+            {
+                SelectedPath = WPerfOptions.Instance.WperfPath,
+            };
+            DialogResult result = fbd.ShowDialog();
+
+            if (result == DialogResult.OK && !string.IsNullOrWhiteSpace(fbd.SelectedPath))
+            {
+                PathInput.Text = fbd.SelectedPath;
+            }
         }
     }
 }


### PR DESCRIPTION
# Introduction

Use the same logic set in WPA Plugin directory settings in wperf path settings.

## In this patch:
feat: use checkbox + add directory selector

# Testing

![image](https://github.com/user-attachments/assets/56b2b124-a40d-4062-8d05-33553ae4bff5)
![image](https://github.com/user-attachments/assets/ef368ea4-57da-4016-9e3c-aff730d39861)

closes https://github.com/arm-developer-tools/windowsperf-vs-extension/issues/18