### PR TITLE
feat: Add sample-display-flag checkbox

### DIFF
--- a/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingDialog.xaml
+++ b/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingDialog.xaml
@@ -12,7 +12,7 @@
     xmlns:toolkit="clr-namespace:Community.VisualStudio.Toolkit;assembly=Community.VisualStudio.Toolkit"
     xmlns:utils="clr-namespace:WindowsPerfGUI.ToolWindows.SamplingSetting"
     Width="1000"
-    Height="600"
+    Height="700"
     toolkit:Themes.UseVsTheme="True"
     mc:Ignorable="d">
     <platform:DialogWindow.DataContext>

--- a/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingDialog.xaml
+++ b/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingDialog.xaml
@@ -116,7 +116,7 @@
                     <TextBlock Text="Enable Kernel Mode" TextWrapping="Wrap" />
                 </CheckBox>
                 <CheckBox Margin="0,5,0,0" IsChecked="{Binding SampleDisplayLong, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
-                    <TextBlock Text="Display decorated symbol name" TextWrapping="Wrap" />
+                    <TextBlock Text="Display decorated symbol names" TextWrapping="Wrap" />
                 </CheckBox>
             </StackPanel>
         </GroupBox>

--- a/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingDialog.xaml
+++ b/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingDialog.xaml
@@ -115,6 +115,9 @@
                 <CheckBox Margin="0,5,0,0" IsChecked="{Binding KernelMode, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
                     <TextBlock Text="Enable Kernel Mode" TextWrapping="Wrap" />
                 </CheckBox>
+                <CheckBox Margin="0,5,0,0" IsChecked="{Binding SampleDisplayLong, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+                    <TextBlock Text="Display decorated symbol name" TextWrapping="Wrap" />
+                </CheckBox>
             </StackPanel>
         </GroupBox>
         <StackPanel Grid.Row="2" Grid.ColumnSpan="2">

--- a/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettings.cs
+++ b/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettings.cs
@@ -78,6 +78,7 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
 
             AppendElementsToList(argsList, "--annotate");
             if (samplingSettingsFrom.ShouldDisassemble) AppendElementsToList(argsList, "--disassemble");
+            if (samplingSettingsFrom.SampleDisplayLong) AppendElementsToList(argsList, "--sample-display-long");
 
             AppendElementsToList(argsList, "--timeout", samplingSettingsFrom.Timeout);
             AppendElementsToList(argsList, "-v", "--json");

--- a/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingsForm.cs
+++ b/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingsForm.cs
@@ -83,6 +83,7 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
             {
                 sampleDisplayLong = value;
                 OnPropertyChanged();
+                CommandLinePreview = GenerateCommandLinePreview();
             }
         }
 
@@ -149,6 +150,7 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
                 ForceLock = samplingSettingsForm.ForceLock;
                 IsSPEEnabled = samplingSettingsForm.IsSPEEnabled;
                 ShouldDisassemble = samplingSettingsForm.ShouldDisassemble;
+                SampleDisplayLong = samplingSettingsForm.SampleDisplayLong;
             }
             SamplingSettings.samplingSettingsFrom = this;
             SamplingSettings.samplingSettingsFrom.SamplingEventList.CollectionChanged +=

--- a/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingsForm.cs
+++ b/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingsForm.cs
@@ -74,6 +74,18 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
             }
         }
 
+        private bool sampleDisplayLong;
+
+        public bool SampleDisplayLong
+        {
+            get { return sampleDisplayLong; }
+            set
+            {
+                sampleDisplayLong = value;
+                OnPropertyChanged();
+            }
+        }
+
         private bool isSPEEnabled;
 
         public bool IsSPEEnabled


### PR DESCRIPTION
This pull request introduces a new feature to the Sampling Settings dialog in the Windows Performance GUI, allowing users to display decorated symbol names. The main changes include adding a new checkbox in the UI, updating the form to handle the new setting, and modifying the command line arguments accordingly.

### New Feature: Display Decorated Symbol Name
* [`WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingDialog.xaml`](diffhunk://#diff-32f60db399e519da2a26f56202224983bcdd66021b58d9bb4f0b4311bd4fdea3R118-R120): Added a new checkbox for enabling the display of decorated symbol names.
* [`WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettings.cs`](diffhunk://#diff-8a29022807d2a7929940a69ea31f4578263932b0c7b1d7b034d32eae764c5abbR81): Updated the command line arguments to include `--sample-display-long` if the new setting is enabled.
* [`WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingsForm.cs`](diffhunk://#diff-f49349689f62c0257d36a11b55e7cc656c1e95580377ddae32aa48fd3a9b0c12R77-R88): Introduced a new property `SampleDisplayLong` to manage the state of the new checkbox and trigger property changes.
## Testing
![{F5C7439D-95EA-4595-AB1E-E8DFDF426E61}](https://github.com/user-attachments/assets/91f0b06b-f970-45e9-91ea-f7dc06030cec)

![{5057AF42-C4BA-41F2-8CDB-4A9013B6E351}](https://github.com/user-attachments/assets/baf327a3-161e-43da-aa94-6e4e3dab19da)

Closes #14 