### PR TITLE
feat: timeline GUI

### DIFF
--- a/WindowsPerfGUI/ToolWindows/CountingSetting/CountingEvent.cs
+++ b/WindowsPerfGUI/ToolWindows/CountingSetting/CountingEvent.cs
@@ -37,5 +37,6 @@ namespace WindowsPerfGUI.ToolWindows.CountingSetting
         public string Name { get; set; }
         public string Index { get; set; }
         public string Note { get; set; }
+        public int Iteration { get; set; } = 0;
     }
 }

--- a/WindowsPerfGUI/ToolWindows/CountingSetting/CountingSettingDialog.xaml
+++ b/WindowsPerfGUI/ToolWindows/CountingSetting/CountingSettingDialog.xaml
@@ -44,110 +44,345 @@
     </platform:DialogWindow.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-        <GroupBox
-            Grid.Row="0"
-            Grid.Column="0"
-            Padding="5">
-            <GroupBox.Header>
-                <Label Content="{x:Static locals:SamplingSettingsLanguagePack.Payload}" />
-            </GroupBox.Header>
-            <StackPanel Orientation="Vertical">
-                <Components:CustomRadioButtonControl
-                    x:Name="CustomProcessRadioButton"
-                    Content="{x:Static locals:SamplingSettingsLanguagePack.PayloadFromFile}"
-                    GroupName="CountingSourceRadioButtonGroup"
-                    IsChecked="{Binding CustomProcessRadioButton, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
-                <Components:FilePicker
-                    x:Name="CountingSourcePathFilePicker"
-                    IsEnabled="{Binding IsChecked, ElementName=CustomProcessRadioButton, Converter={StaticResource NullToDisabledConverter}}"
-                    OnChange="FilePickerTextBox_TextChanged" />
-                <StackPanel Orientation="Horizontal">
-                    <Components:CustomRadioButtonControl
-                        x:Name="CurrentProjectProcessRadioButton"
-                        Content="{x:Static locals:SamplingSettingsLanguagePack.ProjectTarget}"
-                        GroupName="CountingSourceRadioButtonGroup"
-                        IsChecked="{Binding CurrentProjectProcessRadioButton, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
-                    <Label x:Name="ProjectTargetConfigLabel" />
-                </StackPanel>
-                <StackPanel Margin="0,10,0,0" Orientation="Horizontal">
-                    <Components:CustomRadioButtonControl
-                        x:Name="NoTargetRadioButton"
-                        Content="{x:Static locals:CountingSettingsLanguagePack.NoTarget}"
-                        GroupName="CountingSourceRadioButtonGroup"
-                        IsChecked="{Binding NoTarget, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
-                    <Label x:Name="NoTargetConfigLabel" />
-                </StackPanel>
-                <Label Content="{x:Static locals:SamplingSettingsLanguagePack.ExtraArgs}" />
-                <Components:CustomTextBoxControl
-                    x:Name="ExtraArgs"
-                    Padding="2"
-                    Placeholder="extra args..."
-                    Text="{Binding ExtraArgs, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
-            </StackPanel>
-        </GroupBox>
-        <GroupBox Grid.Row="1" Padding="5">
-            <GroupBox.Header>
-                <Label Content="{x:Static locals:SamplingSettingsLanguagePack.Parameters}" />
-            </GroupBox.Header>
-            <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <StackPanel>
-                    <Label
-                        Grid.Row="2"
-                        Grid.Column="0"
-                        Content="{x:Static locals:SamplingSettingsLanguagePack.Timeout}" />
-                    <Components:CustomTextBoxControl
-                        x:Name="CountingTimeoutTextBox"
-                        Grid.Row="2"
-                        Grid.Column="1"
-                        Margin="0,0,0,10"
-                        Padding="2"
-                        Placeholder="2.5"
-                        Text="{Binding Timeout, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
-                    <CheckBox
-                        x:Name="EnableTimelineRadioButton"
-                        Content="Timeline"
-                        IsChecked="{Binding IsTimelineSelected, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
-                    <StackPanel Visibility="{Binding IsTimelineSelected, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <Label Content="Iterations" />
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <GroupBox
+                    Grid.Row="0"
+                    Grid.Column="0"
+                    Padding="5">
+                    <GroupBox.Header>
+                        <Label Content="{x:Static locals:SamplingSettingsLanguagePack.Payload}" />
+                    </GroupBox.Header>
+                    <StackPanel Orientation="Vertical">
+                        <Components:CustomRadioButtonControl
+                            x:Name="CustomProcessRadioButton"
+                            Content="{x:Static locals:SamplingSettingsLanguagePack.PayloadFromFile}"
+                            GroupName="CountingSourceRadioButtonGroup"
+                            IsChecked="{Binding CustomProcessRadioButton, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                        <Components:FilePicker
+                            x:Name="CountingSourcePathFilePicker"
+                            IsEnabled="{Binding IsChecked, ElementName=CustomProcessRadioButton, Converter={StaticResource NullToDisabledConverter}}"
+                            OnChange="FilePickerTextBox_TextChanged" />
+                        <StackPanel Orientation="Horizontal">
+                            <Components:CustomRadioButtonControl
+                                x:Name="CurrentProjectProcessRadioButton"
+                                Content="{x:Static locals:SamplingSettingsLanguagePack.ProjectTarget}"
+                                GroupName="CountingSourceRadioButtonGroup"
+                                IsChecked="{Binding CurrentProjectProcessRadioButton, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                            <Label x:Name="ProjectTargetConfigLabel" />
+                        </StackPanel>
+                        <StackPanel Margin="0,10,0,0" Orientation="Horizontal">
+                            <Components:CustomRadioButtonControl
+                                x:Name="NoTargetRadioButton"
+                                Content="{x:Static locals:CountingSettingsLanguagePack.NoTarget}"
+                                GroupName="CountingSourceRadioButtonGroup"
+                                IsChecked="{Binding NoTarget, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                            <Label x:Name="NoTargetConfigLabel" />
+                        </StackPanel>
+                        <Label Content="{x:Static locals:SamplingSettingsLanguagePack.ExtraArgs}" />
                         <Components:CustomTextBoxControl
-                            x:Name="CountingTimelineIterations"
+                            x:Name="ExtraArgs"
                             Padding="2"
-                            Placeholder="1"
-                            Text="{Binding TimelineIterations, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
-                        <Label Content="Interval" />
-                        <Components:CustomTextBoxControl
-                            x:Name="CountingTimelineInterval"
-                            Padding="2"
-                            Placeholder="0.5"
-                            Text="{Binding TimelineInterval, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                            Placeholder="extra args..."
+                            Text="{Binding ExtraArgs, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
                     </StackPanel>
-                    <Label
-                        Grid.Row="0"
-                        Grid.Column="0"
-                        Content="{x:Static locals:SamplingSettingsLanguagePack.CpuCore}" />
-                    <Components:ButtonGrid
-                        x:Name="CpuCoresGrid"
-                        FilePath="{Binding FilePath}"
-                        SelectedColor="{StaticResource VizSurfaceGreenMedium}"
-                        SelectedItems="{Binding CPUCores, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
-                    <CheckBox Margin="0,5,0,0" IsChecked="{Binding ForceLock, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
-                        <TextBlock Text="{x:Static locals:MainLanguagePack.ForceLock}" TextWrapping="Wrap" />
-                    </CheckBox>
-                    <CheckBox Margin="0,5,0,0" IsChecked="{Binding KernelMode, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
-                        <TextBlock Text="Enable Kernel Mode" TextWrapping="Wrap" />
-                    </CheckBox>
-                </StackPanel>
-            </ScrollViewer>
-        </GroupBox>
+                </GroupBox>
+                <GroupBox Grid.Row="1" Padding="5">
+                    <GroupBox.Header>
+                        <Label Content="{x:Static locals:SamplingSettingsLanguagePack.Parameters}" />
+                    </GroupBox.Header>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <StackPanel>
+                            <Label
+                                Grid.Row="2"
+                                Grid.Column="0"
+                                Content="{x:Static locals:SamplingSettingsLanguagePack.Timeout}" />
+                            <Components:CustomTextBoxControl
+                                x:Name="CountingTimeoutTextBox"
+                                Grid.Row="2"
+                                Grid.Column="1"
+                                Margin="0,0,0,10"
+                                Padding="2"
+                                Placeholder="2.5"
+                                Text="{Binding Timeout, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                            <CheckBox
+                                x:Name="EnableTimelineRadioButton"
+                                Content="Timeline"
+                                IsChecked="{Binding IsTimelineSelected, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                            <StackPanel Visibility="{Binding IsTimelineSelected, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <Label Content="Iterations" />
+                                <Components:CustomTextBoxControl
+                                    x:Name="CountingTimelineIterations"
+                                    Padding="2"
+                                    Placeholder="1"
+                                    Text="{Binding TimelineIterations, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                                <Label Content="Interval" />
+                                <Components:CustomTextBoxControl
+                                    x:Name="CountingTimelineInterval"
+                                    Padding="2"
+                                    Placeholder="0.5"
+                                    Text="{Binding TimelineInterval, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                            </StackPanel>
+                            <Label
+                                Grid.Row="0"
+                                Grid.Column="0"
+                                Content="{x:Static locals:SamplingSettingsLanguagePack.CpuCore}" />
+                            <Components:ButtonGrid
+                                x:Name="CpuCoresGrid"
+                                FilePath="{Binding FilePath}"
+                                SelectedColor="{StaticResource VizSurfaceGreenMedium}"
+                                SelectedItems="{Binding CPUCores, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                            <CheckBox Margin="0,5,0,0" IsChecked="{Binding ForceLock, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+                                <TextBlock Text="{x:Static locals:MainLanguagePack.ForceLock}" TextWrapping="Wrap" />
+                            </CheckBox>
+                            <CheckBox Margin="0,5,0,0" IsChecked="{Binding KernelMode, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+                                <TextBlock Text="Enable Kernel Mode" TextWrapping="Wrap" />
+                            </CheckBox>
+                        </StackPanel>
+                    </ScrollViewer>
+                </GroupBox>
+                <GroupBox
+                    Grid.Row="0"
+                    Grid.RowSpan="2"
+                    Grid.Column="1"
+                    Margin="5,0,0,0">
+                    <GroupBox.Header>
+                        <Label Content="{x:Static locals:SamplingSettingsLanguagePack.EventHeader}" />
+                    </GroupBox.Header>
+                    <StackPanel>
+                        <Label Content="{x:Static locals:SamplingSettingsLanguagePack.RawEvent}" />
+                        <Grid Margin="0,0,0,10">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="50" />
+                            </Grid.ColumnDefinitions>
+                            <Grid Grid.Column="0">
+                                <Components:CustomTextBoxControl
+                                    x:Name="RawEventsInput"
+                                    Padding="2"
+                                    Placeholder="rF123"
+                                    Text="{Binding RawEvents, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                            </Grid>
+                            <Grid Grid.Column="1">
+                                <Components:CustomMonikerButtonControl
+                                    x:Name="AddRawEventButton"
+                                    Margin="5,0,0,0"
+                                    Click="AddRawEventButton_Click"
+                                    IsEnabled="{Binding Text, ElementName=RawEventsInput, Converter={StaticResource EmptyStringToDisabledConverter}}"
+                                    MonikerName="{x:Static catalog:KnownMonikers.Add}" />
+                            </Grid>
+                        </Grid>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Grid
+                                Grid.Column="0"
+                                Grid.ColumnSpan="2"
+                                Margin="0,0,5,10">
+                                <Components:FilterableComboBox
+                                    x:Name="EventComboBox"
+                                    GotFocus="EventComboBox_GotFocus"
+                                    OnlyValuesInList="True"
+                                    SelectedItem="{Binding SelectedEvent, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+                                    <Components:FilterableComboBox.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <VirtualizingStackPanel VirtualizationMode="Recycling" />
+                                        </ItemsPanelTemplate>
+                                    </Components:FilterableComboBox.ItemsPanel>
+                                </Components:FilterableComboBox>
+
+                                <TextBlock
+                                    x:Name="EventComboBoxPlaceholder"
+                                    Margin="5,3,20,0"
+                                    IsHitTestVisible="False"
+                                    Text="{x:Static locals:SamplingSettingsLanguagePack.Event}" />
+                            </Grid>
+                            <StackPanel Grid.Column="2" Orientation="Horizontal">
+                                <Components:CustomMonikerButtonControl
+                                    x:Name="AddEventButton"
+                                    Margin="5,0,0,10"
+                                    Click="AddEventButton_Click"
+                                    IsEnabled="{Binding SelectedItem, ElementName=EventComboBox, Converter={StaticResource NullToDisabledConverter}}"
+                                    MonikerName="{x:Static catalog:KnownMonikers.Add}" />
+                                <Components:CustomMonikerButtonControl
+                                    x:Name="RemoveEventButton"
+                                    Margin="5,0,0,10"
+                                    Click="RemoveEventButton_Click"
+                                    IsEnabled="{Binding SelectedIndex, ElementName=CountingEventListBox, Converter={StaticResource NegativeIntToDisabledConverter}}"
+                                    MonikerName="{x:Static catalog:KnownMonikers.Remove}" />
+                            </StackPanel>
+                        </Grid>
+                        <Grid Margin="0,10,0,5">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="20" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Grid Grid.Row="0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="20" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock
+                                    Grid.Column="0"
+                                    Grid.ColumnSpan="2"
+                                    Margin="7,0,5,0"
+                                    Text="{x:Static locals:SamplingSettingsLanguagePack.Events}" />
+                            </Grid>
+                            <StackPanel Grid.Row="1" Grid.RowSpan="2">
+                                <ListBox
+                                    x:Name="CountingEventListBox"
+                                    d:ItemsSource="{d:SampleData ItemCount=5}"
+                                    BorderBrush="Transparent"
+                                    ItemsSource="{Binding CountingEventList}"
+                                    ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                    SelectionChanged="CountingEventListBox_SelectionChanged"
+                                    SelectionMode="Multiple">
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock
+                                                x:Name="Parameter"
+                                                Grid.Column="1"
+                                                Text="{Binding}" />
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                                <Components:CustomButtonControl
+                                    x:Name="GroupEventButton"
+                                    Margin="0,10,0,10"
+                                    Padding="20,5,20,5"
+                                    HorizontalAlignment="Right"
+                                    Click="CustomButtonControl_Click"
+                                    Content="{x:Static locals:CountingSettingsLanguagePack.GroupEvents}"
+                                    IsEnabled="False" />
+                            </StackPanel>
+                        </Grid>
+                    </StackPanel>
+                </GroupBox>
+                <GroupBox
+                    Grid.RowSpan="2"
+                    Grid.Column="2"
+                    Margin="5,0,0,0">
+                    <GroupBox.Header>
+                        <Label Content="{x:Static locals:CountingSettingsLanguagePack.MetricList}" />
+                    </GroupBox.Header>
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Grid
+                                Grid.Column="0"
+                                Grid.ColumnSpan="2"
+                                Margin="0,0,5,10">
+                                <StackPanel>
+                                    <Label Content="{x:Static locals:CountingSettingsLanguagePack.Metrics}" />
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <Components:FilterableComboBox
+                                            x:Name="MetricComboBox"
+                                            GotFocus="MetricComboBox_GotFocus"
+                                            OnlyValuesInList="True"
+                                            SelectedItem="{Binding SelectedEvent, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+                                            <Components:FilterableComboBox.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <VirtualizingStackPanel VirtualizationMode="Recycling" />
+                                                </ItemsPanelTemplate>
+                                            </Components:FilterableComboBox.ItemsPanel>
+                                        </Components:FilterableComboBox>
+                                        <TextBlock
+                                            x:Name="MetricComboBoxPlaceholder"
+                                            Grid.Column="0"
+                                            Margin="5,3,20,0"
+                                            IsHitTestVisible="False"
+                                            Text="{x:Static locals:CountingSettingsLanguagePack.MetricComboboxPlaceholder}" />
+                                        <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                            <Components:CustomMonikerButtonControl
+                                                x:Name="AddMetricButton"
+                                                Margin="5,0,0,10"
+                                                Click="AddMetricButton_Click"
+                                                IsEnabled="{Binding SelectedItem, ElementName=MetricComboBox, Converter={StaticResource NullToDisabledConverter}}"
+                                                MonikerName="{x:Static catalog:KnownMonikers.Add}" />
+                                            <Components:CustomMonikerButtonControl
+                                                x:Name="RemoveMetricButton"
+                                                Margin="5,0,0,10"
+                                                Click="RemoveMetricButton_Click"
+                                                IsEnabled="{Binding SelectedIndex, ElementName=CountingMetricListBox, Converter={StaticResource NegativeIntToDisabledConverter}}"
+                                                MonikerName="{x:Static catalog:KnownMonikers.Remove}" />
+                                        </StackPanel>
+                                    </Grid>
+                                </StackPanel>
+                            </Grid>
+
+                        </Grid>
+                        <Grid Margin="0,10,0,5">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="20" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Grid Grid.Row="0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="20" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock
+                                    Grid.Column="0"
+                                    Grid.ColumnSpan="2"
+                                    Margin="7,0,5,0"
+                                    Text="{x:Static locals:CountingSettingsLanguagePack.Metrics}" />
+                            </Grid>
+                            <ListBox
+                                x:Name="CountingMetricListBox"
+                                Grid.Row="1"
+                                Grid.RowSpan="2"
+                                d:ItemsSource="{d:SampleData ItemCount=5}"
+                                BorderBrush="Transparent"
+                                ItemsSource="{Binding CountingMetricList}"
+                                ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                SelectionChanged="CountingMetricListBox_SelectionChanged"
+                                SelectionMode="Multiple">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid x:Name="GridItem">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="20" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock
+                                                x:Name="Parameter"
+                                                Grid.Column="0"
+                                                Grid.ColumnSpan="2"
+                                                Text="{Binding}" />
+                                        </Grid>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </Grid>
+                    </StackPanel>
+                </GroupBox>
+
+            </Grid>
+        </ScrollViewer>
         <StackPanel Grid.Row="2" Grid.ColumnSpan="3">
             <Label Content="{x:Static locals:SamplingSettingsLanguagePack.WperfCommandPreview}" />
             <Components:CustomTextBoxControl
@@ -189,22 +424,7 @@
                     <Label Content="{x:Static locals:CountingSettingsLanguagePack.CountingOutput}" />
                 </GroupBox.Header>
                 <StackPanel>
-                    <DataGrid
-                        Height="150"
-                        Padding="0"
-                        AutoGenerateColumns="True"
-                        AutoGeneratingColumn="DataGrid_OnAutoGeneratingColumn"
-                        Background="{StaticResource VsInputBackground}"
-                        BorderThickness="0"
-                        ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}"
-                        Foreground="{StaticResource ToolWindowText}"
-                        HeadersVisibility="Column"
-                        HorizontalGridLinesBrush="{StaticResource ToolWindowText}"
-                        IsReadOnly="True"
-                        ItemsSource="{Binding CountingResult}"
-                        RowBackground="{StaticResource VsInputBackground}"
-                        VerticalGridLinesBrush="{StaticResource ToolWindowText}" />
-
+                    <StackPanel x:Name="CountingOutputContainer" MinHeight="150" />
                     <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
                         <Components:CustomButtonControl
                             x:Name="SaveAsButton"
@@ -222,231 +442,5 @@
                 </StackPanel>
             </GroupBox>
         </StackPanel>
-        <GroupBox
-            Grid.Row="0"
-            Grid.RowSpan="2"
-            Grid.Column="1"
-            Margin="5,0,0,0">
-            <GroupBox.Header>
-                <Label Content="{x:Static locals:SamplingSettingsLanguagePack.EventHeader}" />
-            </GroupBox.Header>
-            <StackPanel>
-                <Label Content="{x:Static locals:SamplingSettingsLanguagePack.RawEvent}" />
-                <Grid Margin="0,0,0,10">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="50" />
-                    </Grid.ColumnDefinitions>
-                    <Grid Grid.Column="0">
-                        <Components:CustomTextBoxControl
-                            x:Name="RawEventsInput"
-                            Padding="2"
-                            Placeholder="rF123"
-                            Text="{Binding RawEvents, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
-                    </Grid>
-                    <Grid Grid.Column="1">
-                        <Components:CustomMonikerButtonControl
-                            x:Name="AddRawEventButton"
-                            Margin="5,0,0,0"
-                            Click="AddRawEventButton_Click"
-                            IsEnabled="{Binding Text, ElementName=RawEventsInput, Converter={StaticResource EmptyStringToDisabledConverter}}"
-                            MonikerName="{x:Static catalog:KnownMonikers.Add}" />
-                    </Grid>
-                </Grid>
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <Grid
-                        Grid.Column="0"
-                        Grid.ColumnSpan="2"
-                        Margin="0,0,5,10">
-                        <Components:FilterableComboBox
-                            x:Name="EventComboBox"
-                            GotFocus="EventComboBox_GotFocus"
-                            OnlyValuesInList="True"
-                            SelectedItem="{Binding SelectedEvent, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
-                            <Components:FilterableComboBox.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <VirtualizingStackPanel VirtualizationMode="Recycling" />
-                                </ItemsPanelTemplate>
-                            </Components:FilterableComboBox.ItemsPanel>
-                        </Components:FilterableComboBox>
-
-                        <TextBlock
-                            x:Name="EventComboBoxPlaceholder"
-                            Margin="5,3,20,0"
-                            IsHitTestVisible="False"
-                            Text="{x:Static locals:SamplingSettingsLanguagePack.Event}" />
-                    </Grid>
-                    <StackPanel Grid.Column="2" Orientation="Horizontal">
-                        <Components:CustomMonikerButtonControl
-                            x:Name="AddEventButton"
-                            Margin="5,0,0,10"
-                            Click="AddEventButton_Click"
-                            IsEnabled="{Binding SelectedItem, ElementName=EventComboBox, Converter={StaticResource NullToDisabledConverter}}"
-                            MonikerName="{x:Static catalog:KnownMonikers.Add}" />
-                        <Components:CustomMonikerButtonControl
-                            x:Name="RemoveEventButton"
-                            Margin="5,0,0,10"
-                            Click="RemoveEventButton_Click"
-                            IsEnabled="{Binding SelectedIndex, ElementName=CountingEventListBox, Converter={StaticResource NegativeIntToDisabledConverter}}"
-                            MonikerName="{x:Static catalog:KnownMonikers.Remove}" />
-                    </StackPanel>
-                </Grid>
-                <Grid Margin="0,10,0,5">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="20" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-                    <Grid Grid.Row="0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="20" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock
-                            Grid.Column="0"
-                            Grid.ColumnSpan="2"
-                            Margin="7,0,5,0"
-                            Text="{x:Static locals:SamplingSettingsLanguagePack.Events}" />
-                    </Grid>
-                    <StackPanel Grid.Row="1" Grid.RowSpan="2">
-                        <ListBox
-                            x:Name="CountingEventListBox"
-                            d:ItemsSource="{d:SampleData ItemCount=5}"
-                            BorderBrush="Transparent"
-                            ItemsSource="{Binding CountingEventList}"
-                            ScrollViewer.VerticalScrollBarVisibility="Auto"
-                            SelectionChanged="CountingEventListBox_SelectionChanged"
-                            SelectionMode="Multiple">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock
-                                        x:Name="Parameter"
-                                        Grid.Column="1"
-                                        Text="{Binding}" />
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
-                        <Components:CustomButtonControl
-                            x:Name="GroupEventButton"
-                            Margin="0,10,0,10"
-                            Padding="20,5,20,5"
-                            HorizontalAlignment="Right"
-                            Click="CustomButtonControl_Click"
-                            Content="{x:Static locals:CountingSettingsLanguagePack.GroupEvents}"
-                            IsEnabled="False" />
-                    </StackPanel>
-                </Grid>
-            </StackPanel>
-        </GroupBox>
-        <GroupBox
-            Grid.RowSpan="2"
-            Grid.Column="2"
-            Margin="5,0,0,0">
-            <GroupBox.Header>
-                <Label Content="{x:Static locals:CountingSettingsLanguagePack.MetricList}" />
-            </GroupBox.Header>
-            <StackPanel>
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <Grid
-                        Grid.Column="0"
-                        Grid.ColumnSpan="2"
-                        Margin="0,0,5,10">
-                        <StackPanel>
-                            <Label Content="{x:Static locals:CountingSettingsLanguagePack.Metrics}" />
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Components:FilterableComboBox
-                                    x:Name="MetricComboBox"
-                                    GotFocus="MetricComboBox_GotFocus"
-                                    OnlyValuesInList="True"
-                                    SelectedItem="{Binding SelectedEvent, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
-                                    <Components:FilterableComboBox.ItemsPanel>
-                                        <ItemsPanelTemplate>
-                                            <VirtualizingStackPanel VirtualizationMode="Recycling" />
-                                        </ItemsPanelTemplate>
-                                    </Components:FilterableComboBox.ItemsPanel>
-                                </Components:FilterableComboBox>
-                                <TextBlock
-                                    x:Name="MetricComboBoxPlaceholder"
-                                    Grid.Column="0"
-                                    Margin="5,3,20,0"
-                                    IsHitTestVisible="False"
-                                    Text="{x:Static locals:CountingSettingsLanguagePack.MetricComboboxPlaceholder}" />
-                                <StackPanel Grid.Column="1" Orientation="Horizontal">
-                                    <Components:CustomMonikerButtonControl
-                                        x:Name="AddMetricButton"
-                                        Margin="5,0,0,10"
-                                        Click="AddMetricButton_Click"
-                                        IsEnabled="{Binding SelectedItem, ElementName=MetricComboBox, Converter={StaticResource NullToDisabledConverter}}"
-                                        MonikerName="{x:Static catalog:KnownMonikers.Add}" />
-                                    <Components:CustomMonikerButtonControl
-                                        x:Name="RemoveMetricButton"
-                                        Margin="5,0,0,10"
-                                        Click="RemoveMetricButton_Click"
-                                        IsEnabled="{Binding SelectedIndex, ElementName=CountingMetricListBox, Converter={StaticResource NegativeIntToDisabledConverter}}"
-                                        MonikerName="{x:Static catalog:KnownMonikers.Remove}" />
-                                </StackPanel>
-                            </Grid>
-                        </StackPanel>
-                    </Grid>
-
-                </Grid>
-                <Grid Margin="0,10,0,5">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="20" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-                    <Grid Grid.Row="0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="20" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock
-                            Grid.Column="0"
-                            Grid.ColumnSpan="2"
-                            Margin="7,0,5,0"
-                            Text="{x:Static locals:CountingSettingsLanguagePack.Metrics}" />
-                    </Grid>
-                    <ListBox
-                        x:Name="CountingMetricListBox"
-                        Grid.Row="1"
-                        Grid.RowSpan="2"
-                        d:ItemsSource="{d:SampleData ItemCount=5}"
-                        BorderBrush="Transparent"
-                        ItemsSource="{Binding CountingMetricList}"
-                        ScrollViewer.VerticalScrollBarVisibility="Auto"
-                        SelectionChanged="CountingMetricListBox_SelectionChanged"
-                        SelectionMode="Multiple">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate>
-                                <Grid x:Name="GridItem">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="20" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock
-                                        x:Name="Parameter"
-                                        Grid.Column="0"
-                                        Grid.ColumnSpan="2"
-                                        Text="{Binding}" />
-                                </Grid>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
-                </Grid>
-            </StackPanel>
-        </GroupBox>
     </Grid>
 </platform:DialogWindow>


### PR DESCRIPTION
# Introduction

Show a combox with the number of iterations in counting timeline. When user selectes an iteration, the `DataGrid` below will show only the events from that iteration.

## In this patch:

feat: timeline display iterations

# Testing

![DDAU9LESQl](https://github.com/user-attachments/assets/4979c1a8-c22c-4927-94f6-a2525c90aa49)
![IQaOPWaOZn](https://github.com/user-attachments/assets/3b1a4421-369f-436c-a894-6965c49d877a)

closes #5
closes #6 