### PR TITLE
feat: time units support in timeline interval / timeout

### DIFF
--- a/WindowsPerfGUI/Options/WPerfOptions.cs
+++ b/WindowsPerfGUI/Options/WPerfOptions.cs
@@ -51,8 +51,8 @@ namespace WindowsPerfGUI.Options
         [DefaultValue(true)]
         public string WperfPath { get; set; } =
             !string.IsNullOrEmpty(WperfDefaults.DefaultWperfPath)
-                ? Path.Combine(WperfDefaults.DefaultWperfPath, "wperf.exe")
-                : "wperf.exe";
+                ? Path.Combine(WperfDefaults.DefaultWperfPath, WperfDefaults.DefaultWperfExecutable)
+                : WperfDefaults.DefaultWperfExecutable;
         public bool WperfVersionCheckIgnore { get; set; } = false;
         public bool IsWperfInitialized { get; set; } = false;
         public bool HasSPESupport { get; set; } = false;

--- a/WindowsPerfGUI/Options/WPerfPath.xaml.cs
+++ b/WindowsPerfGUI/Options/WPerfPath.xaml.cs
@@ -60,7 +60,10 @@ namespace WindowsPerfGUI.Options
             {
                 WperfDefaultPathCheckbox.IsChecked = true;
                 PathInput.IsEnabled = false;
-                PathInput.Text = Path.Combine(WperfDefaults.DefaultWperfPath, "wperf.exe");
+                PathInput.Text = Path.Combine(
+                    WperfDefaults.DefaultWperfPath,
+                    WperfDefaults.DefaultWperfExecutable
+                );
                 SelectDirectoryButton.IsEnabled = false;
             }
             if (!string.IsNullOrEmpty(WperfDefaults.DefaultWperfPath))
@@ -204,7 +207,10 @@ namespace WindowsPerfGUI.Options
             SelectDirectoryButton.IsEnabled = !newValue;
             if (newValue)
             {
-                PathInput.Text = Path.Combine(WperfDefaults.DefaultWperfPath, "wperf.exe");
+                PathInput.Text = Path.Combine(
+                    WperfDefaults.DefaultWperfPath,
+                    WperfDefaults.DefaultWperfExecutable
+                );
             }
 
             WPerfOptions.Instance.UseDefaultWperfLocation = newValue;

--- a/WindowsPerfGUI/Resources/Locals/ErrorLanguagePack.Designer.cs
+++ b/WindowsPerfGUI/Resources/Locals/ErrorLanguagePack.Designer.cs
@@ -88,6 +88,18 @@ namespace WindowsPerfGUI.Resources.Locals {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Incorrect time format.
+        ///Time should be of format &lt;time&gt;&lt;unit&gt; where unit is optional.
+        ///Supported units are: ms, s, m, h, d.
+        ///Examples: 10, 0.5, 50ms, 2.5m.
+        /// </summary>
+        public static string IncorrectTimeStringFormat {
+            get {
+                return ResourceManager.GetString("IncorrectTimeStringFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This version of the extention was built to only support WindowsPerf version {0}!.
         /// </summary>
         public static string MinimumVersionMismatch {

--- a/WindowsPerfGUI/Resources/Locals/ErrorLanguagePack.fr-FR.resx
+++ b/WindowsPerfGUI/Resources/Locals/ErrorLanguagePack.fr-FR.resx
@@ -173,4 +173,10 @@ Par exemple, r10 est un événement avec l'index 0x10</value>
   <data name="WPAPluginNotInstalled" xml:space="preserve">
     <value>Impossible de détecter le plug-in WindowsPerf WPA. Veuillez vous assurer que le plugin est correctement installé.</value>
   </data>
+  <data name="IncorrectTimeStringFormat" xml:space="preserve">
+    <value>Format de temps incorrect. 
+Le temps doit être au format &lt;time&gt;&lt;unit&gt; où l'unité est facultative.
+Les unités prises en charge sont : ms, s, m, h, d.
+Exemples : 10, 0.5, 50ms, 2.5m</value>
+  </data>
 </root>

--- a/WindowsPerfGUI/Resources/Locals/ErrorLanguagePack.resx
+++ b/WindowsPerfGUI/Resources/Locals/ErrorLanguagePack.resx
@@ -173,4 +173,10 @@ For example r10 is event with index 0x10</value>
   <data name="WPAPluginNotInstalled" xml:space="preserve">
     <value>Could not detect WindowsPerf WPA Plugin. Please make sure the plugin is installed correctly.</value>
   </data>
+  <data name="IncorrectTimeStringFormat" xml:space="preserve">
+    <value>Incorrect time format.
+Time should be of format &lt;time&gt;&lt;unit&gt; where unit is optional.
+Supported units are: ms, s, m, h, d.
+Examples: 10, 0.5, 50ms, 2.5m</value>
+  </data>
 </root>

--- a/WindowsPerfGUI/ToolWindows/CountingSetting/CountingSettingDialog.xaml.cs
+++ b/WindowsPerfGUI/ToolWindows/CountingSetting/CountingSettingDialog.xaml.cs
@@ -132,6 +132,15 @@ namespace WindowsPerfGUI.ToolWindows.CountingSetting
             UpdateCountingCommandCallTextBox();
         }
 
+        private static bool IsTimeStringValid(string timeString)
+        {
+            var validTimeStringRegex = new Regex("^\\d+(\\.?\\d+)?((ms)|s|m|h|d)?$");
+            bool isValid =
+                string.IsNullOrEmpty(timeString) || validTimeStringRegex.Match(timeString).Success;
+
+            return isValid;
+        }
+
         private void StartCounting_Click(object sender, RoutedEventArgs e)
         {
             if (!WPerfOptions.Instance.IsWperfInitialized)
@@ -139,6 +148,16 @@ namespace WindowsPerfGUI.ToolWindows.CountingSetting
             if (!CountingSettings.AreSettingsFilled)
             {
                 VS.MessageBox.ShowError(ErrorLanguagePack.IncompleteCountingSettingsLine1);
+                return;
+            }
+
+            bool areTimeStringsValid =
+                IsTimeStringValid(CountingSettings.countingSettingsForm.TimelineInterval)
+                && IsTimeStringValid(CountingSettings.countingSettingsForm.Timeout);
+
+            if (!areTimeStringsValid)
+            {
+                VS.MessageBox.ShowError(ErrorLanguagePack.IncorrectTimeStringFormat);
                 return;
             }
 

--- a/WindowsPerfGUI/ToolWindows/CountingSetting/CountingSettings.cs
+++ b/WindowsPerfGUI/ToolWindows/CountingSetting/CountingSettings.cs
@@ -49,15 +49,15 @@ namespace WindowsPerfGUI.ToolWindows.CountingSetting
             }
             if (countingSettingsForm == null)
                 throw new ArgumentNullException(nameof(countingSettingsForm));
-            List<string> argsList = new List<string>();
+            List<string> argsList = new();
             ValidateSettings();
             AppendElementsToList(argsList, "stat");
 
             AppendElementsToList(
-             argsList,
-             "-e",
-             string.Join(",", countingSettingsForm.CountingEventList)
-         );
+                argsList,
+                "-e",
+                string.Join(",", countingSettingsForm.CountingEventList)
+            );
             AppendElementsToList(
                 argsList,
                 "-m",
@@ -82,8 +82,10 @@ namespace WindowsPerfGUI.ToolWindows.CountingSetting
 
             AppendElementsToList(argsList, "--timeout", countingSettingsForm.Timeout);
             AppendElementsToList(argsList, "--json");
-            if (countingSettingsForm.ForceLock) AppendElementsToList(argsList, "--force-lock");
-            if (countingSettingsForm.KernelMode) AppendElementsToList(argsList, "-k");
+            if (countingSettingsForm.ForceLock)
+                AppendElementsToList(argsList, "--force-lock");
+            if (countingSettingsForm.KernelMode)
+                AppendElementsToList(argsList, "-k");
 
             if (!countingSettingsForm.NoTarget)
             {

--- a/WindowsPerfGUI/Utils/WperfDefaults.cs
+++ b/WindowsPerfGUI/Utils/WperfDefaults.cs
@@ -48,5 +48,7 @@ namespace WindowsPerfGUI.Utils
         public static string DefaultWperfPath = Environment.GetEnvironmentVariable(
             "WINDOWSPERF_PATH"
         );
+
+        public static string DefaultWperfExecutable = "wperf.exe";
     }
 }


### PR DESCRIPTION
# Introduction

Support time units in timeout and timeline interval. An error message is shown if the format is not supported. Uses the following regex to match correct format.

`^\d+(\.?\d+)?((ms)|s|m|h|d)?$`

Also extracts the `"wperf.exe"` string in a seperate constant.

## In this patch:

feat: time units support in t imeline interval / timeout

# Testing

![scPYHotdZr](https://github.com/user-attachments/assets/d6cee6ba-47b4-4360-a5c6-cb8aabd68bad)

closes #7
closes #8