### PR TITLE
feat: disassembly syntax highlighting

### DIFF
--- a/WindowsPerfGUI/Options/SamplingManager.cs
+++ b/WindowsPerfGUI/Options/SamplingManager.cs
@@ -29,6 +29,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using System.ComponentModel;
+using System.Drawing;
 using System.Runtime.InteropServices;
 
 namespace WindowsPerfGUI.Options
@@ -41,12 +42,62 @@ namespace WindowsPerfGUI.Options
 
     public class SamplingManager : BaseOptionModel<SamplingManager>
     {
-        [Category("Windows Perf")]
+        [Category("Code Annotations")]
         [DisplayName("Highlighter Color Resolution")]
         [Description(
             "The resolution of the colors to use in the line highlighter. Please chose a value between 3 and 256, defaulting to 3 otherwise."
         )]
         [DefaultValue(3)]
         public int HighlighterColorResolution { get; set; } = 3;
+
+        [Category("Syntax Highlighting")]
+        [DisplayName("Disassembly Syntax Highlighting")]
+        [Description("Enables or disables disassembly syntax highlighting")]
+        public bool EnableDisassemblySyntaxHighlighting { get; set; } = true;
+
+        [Category("Disassembly Syntax Highlighting Colors")]
+        [DisplayName("Mnemonic Color")]
+        [Description("Sets the color of mnemonics")]
+        public Color MnemonicColor { get; set; } = Color.MediumPurple;
+
+        [Category("Disassembly Syntax Highlighting Colors")]
+        [DisplayName("Memory Address Color")]
+        [Description("Sets the color of memory addresses")]
+        public Color AddressColor { get; set; } = Color.LimeGreen;
+
+        [Category("Disassembly Syntax Highlighting Colors")]
+        [DisplayName("Comment Color")]
+        [Description("Sets the color of inline comments")]
+        public Color CommentColor { get; set; } = Color.Gray;
+
+        [Category("Disassembly Syntax Highlighting Colors")]
+        [DisplayName("Update Modifier Color")]
+        [Description("Sets the color of the \"!\" modifier")]
+        public Color UpdateModifierColor { get; set; } = Color.Yellow;
+
+        [Category("Disassembly Syntax Highlighting Colors")]
+        [DisplayName("Symbolic Notation Color")]
+        [Description("Sets the color of items enclosed in angle brackets.")]
+        public Color SymbolicNotationColor { get; set; } = Color.MediumVioletRed;
+
+        [Category("Disassembly Syntax Highlighting Colors")]
+        [DisplayName("Argument Separator Color")]
+        [Description("Sets the color of the \",\" separator")]
+        public Color SeparatorColor { get; set; } = Color.White;
+
+        [Category("Disassembly Syntax Highlighting Colors")]
+        [DisplayName("Memory Adressing and Register List Color")]
+        [Description("Sets the color of items enclosed in either \"{}\" or \"[]\"")]
+        public Color GroupColor { get; set; } = Color.LightGreen;
+
+        [Category("Disassembly Syntax Highlighting Colors")]
+        [DisplayName("Immediate Value Color")]
+        [Description("Sets the color of immediate values (eg: #0x01)")]
+        public Color ImmediateValueColor { get; set; } = Color.SkyBlue;
+
+        [Category("Disassembly Syntax Highlighting Colors")]
+        [DisplayName("Register Color")]
+        [Description("Sets the color of registers.")]
+        public Color RegisterColor { get; set; } = Color.LightPink;
     }
 }

--- a/WindowsPerfGUI/ToolWindows/SamplingExplorer/LineHighlighting/HighlighterDict.cs
+++ b/WindowsPerfGUI/ToolWindows/SamplingExplorer/LineHighlighting/HighlighterDict.cs
@@ -28,8 +28,8 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-using Microsoft.VisualStudio.Text.Editor;
 using System.Collections.Generic;
+using Microsoft.VisualStudio.Text.Editor;
 
 namespace WindowsPerfGUI.ToolWindows.SamplingExplorer.LineHighlighting
 {
@@ -72,7 +72,10 @@ namespace WindowsPerfGUI.ToolWindows.SamplingExplorer.LineHighlighting
                 return;
             FilePaths.Add(samplingSection.Name.ToLower());
 
-            FilesToHighlight.TryGetValue(samplingSection.Name.ToLower(), out FileToHighlight fileToHighlight);
+            FilesToHighlight.TryGetValue(
+                samplingSection.Name.ToLower(),
+                out FileToHighlight fileToHighlight
+            );
 
             if (fileToHighlight == null)
             {
@@ -108,6 +111,10 @@ namespace WindowsPerfGUI.ToolWindows.SamplingExplorer.LineHighlighting
                 return;
             }
             IWpfTextView _view = activeDocument?.TextView;
+            if (_view == null)
+            {
+                return;
+            }
             IAdornmentLayer _layer = _view.GetAdornmentLayer("LineHighlighter");
             LineHighlighter.RefreshTextHighlights(_view, _layer, 3);
         }

--- a/WindowsPerfGUI/WindowsPerfGUI.csproj
+++ b/WindowsPerfGUI/WindowsPerfGUI.csproj
@@ -314,6 +314,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Design" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />


### PR DESCRIPTION
# Introduction

Add a new disassembly syntax highlighting feature fully user customizable. Users can customize colors used in the syntax highlighting as well as opting out from it in the `Tools > Options > WindowsPerf > Sampling Manager` option menu.

## In this patch:

feat: disassembly syntax highlighting

# Testing

https://github.com/user-attachments/assets/1fd70199-4fb7-4b30-bedf-4a16f2577770


closes #27 