### PR TITLE
fix: SPE json import

### DIFF
--- a/WindowsPerfGUI/ToolWindows/SamplingExplorer/SamplingExplorerControl.xaml.cs
+++ b/WindowsPerfGUI/ToolWindows/SamplingExplorer/SamplingExplorerControl.xaml.cs
@@ -30,15 +30,12 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Media;
-using CliWrap.Builders;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.Win32;
@@ -1050,12 +1047,16 @@ namespace WindowsPerfGUI.ToolWindows.SamplingExplorer
             using StreamReader reader = new(filename);
 
             string json = reader.ReadToEnd();
+            bool isSPESampling = JsonTypeChecker.IsJsonType<WperfSPE>(json);
+
+            WperfSampling samplingSection = isSPESampling
+                ? WperfSPE.FromJson(json).Sampling
+                : WperfSampling.FromJson(json);
 
             try
             {
-                WperfSampling wperfSampling = WperfSampling.FromJson(json);
                 formattedSamplingResults.FormatSamplingResults(
-                    wperfSampling,
+                    samplingSection,
                     $"Read from file: {filename}"
                 );
 

--- a/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingDialog.xaml.cs
+++ b/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingDialog.xaml.cs
@@ -28,11 +28,11 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-using Microsoft.VisualStudio.PlatformUI;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows;
+using Microsoft.VisualStudio.PlatformUI;
 using WindowsPerfGUI.Options;
 using WindowsPerfGUI.Resources.Locals;
 using WindowsPerfGUI.SDK.WperfOutputs;
@@ -75,16 +75,18 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
                 EnableSPECheckBox.IsEnabled = false;
             }
         }
+
         private void ResetEventComboBox()
         {
             var eventList = new List<PredefinedEvent>(
                 SamplingSettings.samplingSettingsFrom.IsSPEEnabled
-                ? WPerfOptions.Instance.WperfList.PredefinedSPEFilters
-                : WPerfOptions.Instance.WperfList.PredefinedEvents
+                    ? WPerfOptions.Instance.WperfList.PredefinedSPEFilters
+                    : WPerfOptions.Instance.WperfList.PredefinedEvents
             );
 
             EventComboBox.ItemsSource = eventList;
         }
+
         private void SaveButton_Click(object sender, RoutedEventArgs e)
         {
             SyncSamplingSettings();
@@ -126,7 +128,9 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
                 SamplingEvent = (EventComboBox.SelectedItem as PredefinedEvent)?.AliasName,
                 SamplingFrequency = SamplingFrequencyComboBox.SelectedItem as string
             };
-            if (!SamplingSettings.samplingSettingsFrom.IsSPEEnabled) newSamplingEventConfig.SamplingFrequency = SamplingFrequencyComboBox.SelectedItem as string ?? WperfDefaults.Frequency;
+            if (!SamplingSettings.samplingSettingsFrom.IsSPEEnabled)
+                newSamplingEventConfig.SamplingFrequency =
+                    SamplingFrequencyComboBox.SelectedItem as string ?? WperfDefaults.Frequency;
             EventComboBox.SelectedIndex = -1;
             SamplingFrequencyComboBox.SelectedIndex = -1;
 
@@ -180,8 +184,8 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
                 VS.MessageBox.ShowError(ErrorLanguagePack.RawEventBadFormat);
                 return;
             }
-            var eventExists = SamplingSettings.samplingSettingsFrom.SamplingEventList.Any(el =>
-                el.SamplingEvent == eventIndex
+            var eventExists = SamplingSettings.samplingSettingsFrom.SamplingEventList.Any(
+                el => el.SamplingEvent == eventIndex
             );
 
             if (eventExists)
@@ -255,7 +259,6 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
             )?.SamplingFrequency;
         }
 
-
         private void HideEventComboBoxPlaceholder()
         {
             EventComboBoxPlaceholder.Visibility = Visibility.Hidden;
@@ -264,7 +267,6 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
         private void CheckBox_Checked(object sender, RoutedEventArgs e)
         {
             ToggleSPEMode(true, true);
-
         }
 
         private void CheckBox_Unchecked(object sender, RoutedEventArgs e)
@@ -274,7 +276,8 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
 
         private void ToggleSPEMode(bool enable, bool forceRefreshList = false)
         {
-            if (EventComboBox == null) return;
+            if (EventComboBox == null)
+                return;
             var eventList = new List<PredefinedEvent>(
                 WPerfOptions.Instance.WperfList.PredefinedEvents
             );
@@ -290,8 +293,10 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
                 RawEventStackPanel.Visibility = Visibility.Collapsed;
                 FrequencyListBoxHeader.Visibility = Visibility.Collapsed;
                 EventListBoxHeader.Text = SamplingSettingsLanguagePack.SPEEventListBoxHeader;
-                EventComboBoxPlaceholder.Text = SamplingSettingsLanguagePack.SPEEventComboBoxPlaceholder;
-                EventGroupBoxHeaderLabel.Content = SamplingSettingsLanguagePack.SPEEventGroupBoxHeaderLabel;
+                EventComboBoxPlaceholder.Text =
+                    SamplingSettingsLanguagePack.SPEEventComboBoxPlaceholder;
+                EventGroupBoxHeaderLabel.Content =
+                    SamplingSettingsLanguagePack.SPEEventGroupBoxHeaderLabel;
             }
             else
             {

--- a/WindowsPerfGUI/Utils/JsonTypeChecker.cs
+++ b/WindowsPerfGUI/Utils/JsonTypeChecker.cs
@@ -28,22 +28,27 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-namespace WindowsPerfGUI.SDK.WperfOutputs
+using Newtonsoft.Json;
+
+namespace WindowsPerfGUI.Utils
 {
-    using Newtonsoft.Json;
-
-    public partial class WperfSPE
+    public class JsonTypeChecker
     {
-        [JsonProperty("sampling", Required = Required.Always)]
-        public WperfSampling Sampling { get; set; }
-
-        [JsonProperty("counting", Required = Required.Always)]
-        public WperfCounting Counting { get; set; }
-    }
-
-    public partial class WperfSPE
-    {
-        public static WperfSPE FromJson(string json) =>
-            JsonConvert.DeserializeObject<WperfSPE>(json, JsonSettings.Settings);
+        public static bool IsJsonType<T>(string jsonString)
+        {
+            try
+            {
+                JsonConvert.DeserializeObject<T>(jsonString);
+                return true;
+            }
+            catch (JsonReaderException)
+            {
+                return false;
+            }
+            catch (JsonSerializationException)
+            {
+                return false;
+            }
+        }
     }
 }

--- a/WindowsPerfGUI/WindowsPerfGUI.csproj
+++ b/WindowsPerfGUI/WindowsPerfGUI.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Utils\Converters\InverseBooleanConverter.cs" />
     <Compile Include="Utils\Converters\BooleanToVisibilityConverter.cs" />
     <Compile Include="Utils\Converters\StringlNullOrEmptyToVisibilityConverter.cs" />
+    <Compile Include="Utils\JsonTypeChecker.cs" />
     <Compile Include="Utils\WperfDefaults.cs" />
     <Compile Include="Utils\Converters\BooleanToLinkCursor.cs" />
     <Compile Include="Utils\Converters\BooleanToLinkTextDecoration.cs" />


### PR DESCRIPTION
# Introduction

Fix importing SPE output in the `Sampling Explorer` pane.

## In this patch:

fix: spe json import


closes #28