### PR TITLE
feat: add record spawn delay support

### DIFF
--- a/WindowsPerfGUI/Resources/Locals/SamplingSettingsLanguagePack.Designer.cs
+++ b/WindowsPerfGUI/Resources/Locals/SamplingSettingsLanguagePack.Designer.cs
@@ -241,6 +241,15 @@ namespace WindowsPerfGUI.Resources.Locals {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Record Spawn Delay (ms).
+        /// </summary>
+        public static string RecordSpawnDelay {
+            get {
+                return ResourceManager.GetString("RecordSpawnDelay", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Start sampling without building the current project.
         /// </summary>
         public static string RunTooltip {

--- a/WindowsPerfGUI/Resources/Locals/SamplingSettingsLanguagePack.fr-FR.resx
+++ b/WindowsPerfGUI/Resources/Locals/SamplingSettingsLanguagePack.fr-FR.resx
@@ -207,4 +207,7 @@
   <data name="EnableSPECheckBoxText" xml:space="preserve">
     <value>Activer mode SPE</value>
   </data>
+  <data name="RecordSpawnDelay" xml:space="preserve">
+    <value>Délai d'enregistrement (ms)</value>
+  </data>
 </root>

--- a/WindowsPerfGUI/Resources/Locals/SamplingSettingsLanguagePack.resx
+++ b/WindowsPerfGUI/Resources/Locals/SamplingSettingsLanguagePack.resx
@@ -207,4 +207,7 @@
   <data name="EnableSPECheckBoxText" xml:space="preserve">
     <value>Enable SPE mode</value>
   </data>
+  <data name="RecordSpawnDelay" xml:space="preserve">
+    <value>Record Spawn Delay (ms)</value>
+  </data>
 </root>

--- a/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingDialog.xaml
+++ b/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingDialog.xaml
@@ -98,6 +98,18 @@
                     Padding="2"
                     Placeholder="2.5"
                     Text="{Binding Timeout, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                <Label
+                    Grid.Row="3"
+                    Grid.Column="0"
+                    Content="{x:Static locals:SamplingSettingsLanguagePack.RecordSpawnDelay}" />
+                <Components:CustomTextBoxControl
+                    x:Name="RecordSpawnDelayTextBox"
+                    Grid.Row="3"
+                    Grid.Column="1"
+                    Margin="0,0,0,10"
+                    Padding="2"
+                    Placeholder="500"
+                    Text="{Binding RecordSpawnDelay, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
 
 
                 <CheckBox Margin="0,10,0,0" IsChecked="{Binding ShouldDisassemble, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">

--- a/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettings.cs
+++ b/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettings.cs
@@ -54,20 +54,21 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
             if (samplingSettingsFrom.IsSPEEnabled)
             {
                 string SPEFilters = string.Join("=1,", samplingSettingsFrom.SamplingEventList);
-                if (samplingSettingsFrom.SamplingEventList.Count > 0) SPEFilters = $"{SPEFilters}=1";
+                if (samplingSettingsFrom.SamplingEventList.Count > 0)
+                    SPEFilters = $"{SPEFilters}=1";
                 AppendElementsToList(
-                argsList,
-                "-e",
-                $"{WperfList.SPE_EVENT_BASE_NAME}{WperfList.SPE_EVENT_SEPARATOR}{SPEFilters}{WperfList.SPE_EVENT_SEPARATOR}"
-            );
+                    argsList,
+                    "-e",
+                    $"{WperfList.SPE_EVENT_BASE_NAME}{WperfList.SPE_EVENT_SEPARATOR}{SPEFilters}{WperfList.SPE_EVENT_SEPARATOR}"
+                );
             }
             else
             {
                 AppendElementsToList(
-                argsList,
-                "-e",
-                string.Join(",", samplingSettingsFrom.SamplingEventList)
-            );
+                    argsList,
+                    "-e",
+                    string.Join(",", samplingSettingsFrom.SamplingEventList)
+                );
             }
 
             AppendElementsToList(
@@ -77,15 +78,29 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
             );
 
             AppendElementsToList(argsList, "--annotate");
-            if (samplingSettingsFrom.ShouldDisassemble) AppendElementsToList(argsList, "--disassemble");
-            if (samplingSettingsFrom.SampleDisplayLong) AppendElementsToList(argsList, "--sample-display-long");
-            if (samplingSettingsFrom.NumberOfRowsPerSample != 50) AppendElementsToList(argsList, "--sample-display-row", samplingSettingsFrom.NumberOfRowsPerSample.ToString());
+            if (samplingSettingsFrom.ShouldDisassemble)
+                AppendElementsToList(argsList, "--disassemble");
+            if (samplingSettingsFrom.SampleDisplayLong)
+                AppendElementsToList(argsList, "--sample-display-long");
+            if (samplingSettingsFrom.NumberOfRowsPerSample != 50)
+                AppendElementsToList(
+                    argsList,
+                    "--sample-display-row",
+                    samplingSettingsFrom.NumberOfRowsPerSample.ToString()
+                );
 
             AppendElementsToList(argsList, "--timeout", samplingSettingsFrom.Timeout);
+            AppendElementsToList(
+                argsList,
+                "--record_spawn_delay",
+                samplingSettingsFrom.RecordSpawnDelay
+            );
             AppendElementsToList(argsList, "-v", "--json");
 
-            if (samplingSettingsFrom.ForceLock) AppendElementsToList(argsList, "--force-lock");
-            if (samplingSettingsFrom.KernelMode) AppendElementsToList(argsList, "-k");
+            if (samplingSettingsFrom.ForceLock)
+                AppendElementsToList(argsList, "--force-lock");
+            if (samplingSettingsFrom.KernelMode)
+                AppendElementsToList(argsList, "-k");
 
             AppendElementsToList(argsList, "--pdb_file", samplingSettingsFrom.PdbFile);
             AppendElementsToList(argsList, "--");
@@ -98,7 +113,10 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
         private static void ValidateSettings()
         {
             AreSettingsFilled = !(
-                (samplingSettingsFrom.SamplingEventList.Count < 1 && !samplingSettingsFrom.IsSPEEnabled)
+                (
+                    samplingSettingsFrom.SamplingEventList.Count < 1
+                    && !samplingSettingsFrom.IsSPEEnabled
+                )
                 || string.IsNullOrEmpty(samplingSettingsFrom.FilePath)
                 || string.IsNullOrEmpty(samplingSettingsFrom.CPUCore?.coreNumber.ToString())
             );

--- a/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingsForm.cs
+++ b/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettingsForm.cs
@@ -142,7 +142,8 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
             set
             {
                 customNumberOfRowsPerSample = value;
-                if (value == false) NumberOfRowsPerSample = 50;
+                if (value == false)
+                    NumberOfRowsPerSample = 50;
                 OnPropertyChanged();
             }
         }
@@ -156,15 +157,16 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
             {
                 samplingEventList = value;
                 OnPropertyChanged();
-                IsEventSelectionEnabled =
-                   value.Count
-                   < WperfDefaults.TotalGPCNum;
+                IsEventSelectionEnabled = value.Count < WperfDefaults.TotalGPCNum;
                 OnPropertyChanged("IsEventSelectionEnabled");
                 CommandLinePreview = GenerateCommandLinePreview();
             }
         }
 
-        internal override string GenerateCommandLinePreview() { return SamplingSettings.GenerateCommandLinePreview(); }
+        internal override string GenerateCommandLinePreview()
+        {
+            return SamplingSettings.GenerateCommandLinePreview();
+        }
 
         public SamplingSettingsForm()
         {
@@ -179,6 +181,7 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
                 SelectedEventFrequency = samplingSettingsForm.SelectedEventFrequency;
                 SelectedEvent = samplingSettingsForm.SelectedEvent;
                 Timeout = samplingSettingsForm.Timeout;
+                RecordSpawnDelay = samplingSettingsForm.RecordSpawnDelay;
                 CPUCore = samplingSettingsForm.CPUCore;
                 ExtraArgs = samplingSettingsForm.ExtraArgs;
                 SamplingEventList = samplingSettingsForm.SamplingEventList;

--- a/WindowsPerfGUI/Utils/CommandBuilder/CommandSettingsForm.cs
+++ b/WindowsPerfGUI/Utils/CommandBuilder/CommandSettingsForm.cs
@@ -224,6 +224,19 @@ namespace WindowsPerfGUI.Utils.CommandBuilder
                 CommandLinePreview = GenerateCommandLinePreview();
             }
         }
+        private string recordSpawnDelay;
+
+        public string RecordSpawnDelay
+        {
+            get { return recordSpawnDelay; }
+            set
+            {
+                recordSpawnDelay = value;
+                OnPropertyChanged();
+                CommandLinePreview = GenerateCommandLinePreview();
+            }
+        }
+
         internal NotifyCollectionChangedEventHandler CollectionUpdater(string callerMemberName)
         {
             return (object sender, NotifyCollectionChangedEventArgs e) =>
@@ -232,6 +245,7 @@ namespace WindowsPerfGUI.Utils.CommandBuilder
                 CommandLinePreview = GenerateCommandLinePreview();
             };
         }
+
         internal abstract string GenerateCommandLinePreview();
     }
 }


### PR DESCRIPTION
# Introduction

Add support for `record_spawn_delay` in sampling settings.

## In this patch:

feat: add record spawn delay support

## Testing

![image](https://github.com/user-attachments/assets/31290213-6400-47fb-9062-99283aaf4381)


closes #25 