### PR TITLE
feat: annotated symbols highlighting

### DIFF
--- a/WindowsPerfGUI/Components/TreeListView/TreeListItem.cs
+++ b/WindowsPerfGUI/Components/TreeListView/TreeListItem.cs
@@ -31,6 +31,9 @@
 using System.ComponentModel;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Shapes;
+using Microsoft.VisualStudio.PlatformUI;
+using WindowsPerfGUI.ToolWindows.SamplingExplorer;
 
 namespace WindowsPerfGUI.Components.TreeListView
 {
@@ -56,6 +59,14 @@ namespace WindowsPerfGUI.Components.TreeListView
 
         protected override void OnMouseDoubleClick(MouseButtonEventArgs e)
         {
+            if (
+                e.OriginalSource is Path
+                || (
+                    e.OriginalSource is Border
+                    && (e.OriginalSource as Border).GetVisualOrLogicalParent() is not TreeListItem
+                )
+            )
+                return;
             if (Node != null && Node.IsExpandable)
             {
                 Node.IsExpanded = !Node.IsExpanded;
@@ -72,17 +83,25 @@ namespace WindowsPerfGUI.Components.TreeListView
                 return;
             }
 
+            Debug.WriteLine(e.Key);
+            Debug.WriteLine((Node.Tag as SamplingSection).Name);
+
             switch (e.Key)
             {
                 case Key.Right:
                     e.Handled = true;
-                    if (!Node.IsExpanded)
+                    if (Node.IsExpandable)
                     {
-                        Node.IsExpanded = true;
-                        ChangeFocus(Node);
+                        if (!Node.IsExpanded)
+                        {
+                            Node.IsExpanded = true;
+                            ChangeFocus(Node);
+                        }
+                        else if (Node.Children.Count > 0)
+                        {
+                            ChangeFocus(Node.Children[0]);
+                        }
                     }
-                    else if (Node.Children.Count > 0)
-                        ChangeFocus(Node.Children[0]);
 
                     break;
 

--- a/WindowsPerfGUI/Components/TreeListView/TreeListItem.cs
+++ b/WindowsPerfGUI/Components/TreeListView/TreeListItem.cs
@@ -33,7 +33,6 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Shapes;
 using Microsoft.VisualStudio.PlatformUI;
-using WindowsPerfGUI.ToolWindows.SamplingExplorer;
 
 namespace WindowsPerfGUI.Components.TreeListView
 {
@@ -82,9 +81,6 @@ namespace WindowsPerfGUI.Components.TreeListView
                 base.OnKeyDown(e);
                 return;
             }
-
-            Debug.WriteLine(e.Key);
-            Debug.WriteLine((Node.Tag as SamplingSection).Name);
 
             switch (e.Key)
             {

--- a/WindowsPerfGUI/Options/SamplingManager.cs
+++ b/WindowsPerfGUI/Options/SamplingManager.cs
@@ -99,5 +99,25 @@ namespace WindowsPerfGUI.Options
         [DisplayName("Register Color")]
         [Description("Sets the color of registers.")]
         public Color RegisterColor { get; set; } = Color.LightPink;
+
+        [Category("Syntax Highlighting")]
+        [DisplayName("Annotated Symbols Syntax Highlighting")]
+        [Description("Enables or disables annotated symbols syntax highlighting")]
+        public bool EnableAnnotatedSymbolsSyntaxHighlighting { get; set; } = true;
+
+        [Category("Annotated Symbols Highlighting Colors")]
+        [DisplayName("Keyword Color")]
+        [Description("Sets the color of keywords.")]
+        public Color KeywordColor { get; set; } = Color.SkyBlue;
+
+        [Category("Annotated Symbols Highlighting Colors")]
+        [DisplayName("Symbol Color")]
+        [Description("Sets the color of symbols.")]
+        public Color SymbolColor { get; set; } = Color.Yellow;
+
+        [Category("Annotated Symbols Highlighting Colors")]
+        [DisplayName("Module Color")]
+        [Description("Sets the color of modules.")]
+        public Color ModuleColor { get; set; } = Color.LightPink;
     }
 }

--- a/WindowsPerfGUI/ToolWindows/SamplingExplorer/SyntaxHighlighting/Rules.cs
+++ b/WindowsPerfGUI/ToolWindows/SamplingExplorer/SyntaxHighlighting/Rules.cs
@@ -1,0 +1,100 @@
+﻿// BSD 3-Clause License
+//
+// Copyright (c) 2024, Arm Limited
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+using WindowsPerfGUI.Options;
+
+namespace WindowsPerfGUI.ToolWindows.SamplingExplorer.SyntaxHighlighting
+{
+    public struct Rule
+    {
+        public string pattern;
+        public System.Drawing.Color color;
+
+        public Rule(string pattern, System.Drawing.Color color)
+        {
+            this.pattern = pattern;
+            this.color = color;
+        }
+    }
+
+    static class Rules
+    {
+        public static Rule[] GetCPPRules()
+        {
+            var keywordPattern =
+                @"\b(int|char|double|float|void|class|struct|public|private|protected|const|unsigned|signed|static|virtual|inline|explicit)\b";
+            var keywordColor = SamplingManager.Instance.KeywordColor;
+
+            var symbolsPattern = @"\(+|\)+|\*+";
+            var symbolColor = SamplingManager.Instance.SymbolColor;
+
+            var modulesPattern = @":\w+\.\w+\b";
+            var moduleColor = SamplingManager.Instance.ModuleColor;
+
+            return
+            [
+                new Rule(keywordPattern, keywordColor),
+                new Rule(symbolsPattern, symbolColor),
+                new Rule(modulesPattern, moduleColor),
+            ];
+        }
+
+        public static Rule[] GetARM64AssemblyRules()
+        {
+            var symbolicPattern = @"<.+>";
+            var symbolicColor = SamplingManager.Instance.SymbolicNotationColor;
+
+            var commentsPattern = @"(\/\/|%%|;|@).+";
+            var commentsColor = SamplingManager.Instance.CommentColor;
+
+            var updatePattern = @"!";
+            var updateColor = SamplingManager.Instance.UpdateModifierColor;
+
+            var separatorPattern = @",";
+            var separatorColor = SamplingManager.Instance.SeparatorColor;
+
+            var groupPattern = @"(\[|]|{|})";
+            var groupColor = SamplingManager.Instance.GroupColor;
+
+            var immediateValuePattern = @"#\w+\b";
+            var immediateValueColor = SamplingManager.Instance.ImmediateValueColor;
+
+            return
+            [
+                new Rule(symbolicPattern, symbolicColor),
+                new Rule(groupPattern, groupColor),
+                new Rule(updatePattern, updateColor),
+                new Rule(separatorPattern, separatorColor),
+                new Rule(immediateValuePattern, immediateValueColor),
+                new Rule(commentsPattern, commentsColor),
+            ];
+        }
+    }
+}

--- a/WindowsPerfGUI/ToolWindows/SamplingExplorer/SyntaxHighlighting/SyntaxHighlighter.cs
+++ b/WindowsPerfGUI/ToolWindows/SamplingExplorer/SyntaxHighlighting/SyntaxHighlighter.cs
@@ -1,0 +1,102 @@
+﻿// BSD 3-Clause License
+//
+// Copyright (c) 2024, Arm Limited
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace WindowsPerfGUI.ToolWindows.SamplingExplorer.SyntaxHighlighting
+{
+    public class SyntaxHighlighter
+    {
+        private static SolidColorBrush DrawingcolorToSolidBrush(System.Drawing.Color color)
+        {
+            return new SolidColorBrush(Color.FromArgb(color.A, color.R, color.G, color.B));
+        }
+
+        public static List<Inline> HighlightCode(
+            string codeLine,
+            Rule[] rules,
+            System.Drawing.Color defaultColor,
+#pragma warning disable CS8632
+            Action<Run>? configureHighlightedRun = null
+#pragma warning restore CS8632
+        )
+        {
+            List<Inline> inlines = [];
+            SolidColorBrush defaultColorBrush = DrawingcolorToSolidBrush(defaultColor);
+
+            int lastIndex = 0;
+            foreach (
+                Match match in Regex.Matches(
+                    codeLine,
+                    $"{string.Join("|", rules.Select((rule) => rule.pattern))}"
+                )
+            )
+            {
+                if (match.Index > lastIndex)
+                {
+                    inlines.Add(
+                        new Run(codeLine.Substring(lastIndex, match.Index - lastIndex))
+                        {
+                            Foreground = defaultColorBrush
+                        }
+                    );
+                }
+
+                System.Drawing.Color tokenColor = defaultColor;
+
+                foreach (var rule in rules)
+                {
+                    if (Regex.IsMatch(match.Value, rule.pattern))
+                        tokenColor = rule.color;
+                }
+
+                Run runToAdd =
+                    new(match.Value) { Foreground = DrawingcolorToSolidBrush(tokenColor) };
+                configureHighlightedRun?.Invoke(runToAdd);
+                inlines.Add(runToAdd);
+                lastIndex = match.Index + match.Length;
+            }
+
+            if (lastIndex < codeLine.Length)
+            {
+                inlines.Add(
+                    new Run(codeLine.Substring(lastIndex)) { Foreground = defaultColorBrush }
+                );
+            }
+
+            return inlines;
+        }
+    }
+}

--- a/WindowsPerfGUI/Utils/VisualTreeHelpers.cs
+++ b/WindowsPerfGUI/Utils/VisualTreeHelpers.cs
@@ -1,0 +1,107 @@
+﻿// BSD 3-Clause License
+//
+// Copyright (c) 2024, Arm Limited
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Threading;
+using WindowsPerfGUI.Components.TreeListView;
+
+namespace WindowsPerfGUI.Utils
+{
+    public static class VisualTreeHelpers
+    {
+        public static T FindVisualChild<T>(
+            this DependencyObject obj,
+            Func<T, bool> predicate = null
+        )
+            where T : DependencyObject
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(obj); i++)
+            {
+                var child = VisualTreeHelper.GetChild(obj, i);
+
+                if (child is T typedChild)
+                {
+                    if (predicate == null || predicate(typedChild))
+                        return typedChild;
+                }
+
+                var childOfChild = FindVisualChild<T>(child, predicate);
+                if (childOfChild != null)
+                    return childOfChild;
+            }
+            return null;
+        }
+
+        public static TextBlock FindTextBlock(TreeListItem container)
+        {
+            return container.FindVisualChild<TextBlock>();
+        }
+
+        public static void UpdateUI()
+        {
+            DispatcherFrame frame = new DispatcherFrame();
+            Dispatcher.CurrentDispatcher.BeginInvoke(
+                DispatcherPriority.Render,
+                new DispatcherOperationCallback(
+                    delegate(object parameter)
+                    {
+                        frame.Continue = false;
+                        return null;
+                    }
+                ),
+                null
+            );
+
+            Dispatcher.PushFrame(frame);
+            Application.Current.Dispatcher.Invoke(
+                DispatcherPriority.Render,
+                new Action(delegate { })
+            );
+        }
+
+        public static ScrollViewer GetScrollViewer(DependencyObject d)
+        {
+            if (d is ScrollViewer)
+                return d as ScrollViewer;
+
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(d); i++)
+            {
+                var child = VisualTreeHelper.GetChild(d, i);
+                var result = GetScrollViewer(child);
+                if (result != null)
+                    return result;
+            }
+
+            return null;
+        }
+    }
+}

--- a/WindowsPerfGUI/WindowsPerfGUI.csproj
+++ b/WindowsPerfGUI/WindowsPerfGUI.csproj
@@ -134,6 +134,8 @@
     </Compile>
     <Compile Include="ToolWindows\CountingSetting\CountingSettings.cs" />
     <Compile Include="ToolWindows\CountingSetting\CountingSettingsForm.cs" />
+    <Compile Include="ToolWindows\SamplingExplorer\SyntaxHighlighting\Rules.cs" />
+    <Compile Include="ToolWindows\SamplingExplorer\SyntaxHighlighting\SyntaxHighlighter.cs" />
     <Compile Include="ToolWindows\SamplingSetting\SolutionProjectOutput.cs" />
     <Compile Include="ToolWindows\SamplingExplorer\LineHighlighting\ColorGenerator.cs" />
     <Compile Include="ToolWindows\SamplingExplorer\LineHighlighting\LineHighlighter.cs" />
@@ -147,6 +149,7 @@
     <Compile Include="Utils\Converters\BooleanToVisibilityConverter.cs" />
     <Compile Include="Utils\Converters\StringlNullOrEmptyToVisibilityConverter.cs" />
     <Compile Include="Utils\JsonTypeChecker.cs" />
+    <Compile Include="Utils\VisualTreeHelpers.cs" />
     <Compile Include="Utils\WperfDefaults.cs" />
     <Compile Include="Utils\Converters\BooleanToLinkCursor.cs" />
     <Compile Include="Utils\Converters\BooleanToLinkTextDecoration.cs" />


### PR DESCRIPTION
# Introduction

Add a new annotated symbols syntax highlighting feature fully user customizable. Users can customize colors used in the syntax highlighting as well as opting out from it in the `Tools > Options > WindowsPerf > Sampling Manager` option menu.

## In this patch:

feat: annotated symbols highlighting

# Testing


https://github.com/user-attachments/assets/99ad62c3-7782-4822-95f4-88591b66f16f


closes #32 