### PR TITLE
fix: wperf path selection

### DIFF
--- a/WindowsPerfGUI/Options/WPerfPath.xaml.cs
+++ b/WindowsPerfGUI/Options/WPerfPath.xaml.cs
@@ -226,7 +226,10 @@ namespace WindowsPerfGUI.Options
 
             if (result == DialogResult.OK && !string.IsNullOrWhiteSpace(fbd.SelectedPath))
             {
-                PathInput.Text = fbd.SelectedPath;
+                PathInput.Text = Path.Combine(
+                    fbd.SelectedPath,
+                    WperfDefaults.DefaultWperfExecutable
+                );
             }
         }
     }


### PR DESCRIPTION
Fixes wperf path selection by combining`wperf.exe` to the end of the selected path