### PR TITLE
fix: remove double dash from command when no target | extra args

### DIFF
--- a/WindowsPerfGUI/ToolWindows/CountingSetting/CountingSettings.cs
+++ b/WindowsPerfGUI/ToolWindows/CountingSetting/CountingSettings.cs
@@ -87,7 +87,10 @@ namespace WindowsPerfGUI.ToolWindows.CountingSetting
             if (countingSettingsForm.KernelMode)
                 AppendElementsToList(argsList, "-k");
 
-            if (!countingSettingsForm.NoTarget)
+            if (
+                !string.IsNullOrEmpty(countingSettingsForm.FilePath)
+                || !string.IsNullOrEmpty(countingSettingsForm.ExtraArgs)
+            )
             {
                 AppendElementsToList(argsList, "--pdb_file", countingSettingsForm.PdbFile);
                 AppendElementsToList(argsList, "--");

--- a/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettings.cs
+++ b/WindowsPerfGUI/ToolWindows/SamplingSetting/SamplingSettings.cs
@@ -103,9 +103,15 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
                 AppendElementsToList(argsList, "-k");
 
             AppendElementsToList(argsList, "--pdb_file", samplingSettingsFrom.PdbFile);
-            AppendElementsToList(argsList, "--");
-            AppendElementsToList(argsList, samplingSettingsFrom.FilePath);
-            AppendElementsToList(argsList, samplingSettingsFrom.ExtraArgs);
+            if (
+                !string.IsNullOrEmpty(samplingSettingsFrom.FilePath)
+                || !string.IsNullOrEmpty(samplingSettingsFrom.ExtraArgs)
+            )
+            {
+                AppendElementsToList(argsList, "--");
+                AppendElementsToList(argsList, samplingSettingsFrom.FilePath);
+                AppendElementsToList(argsList, samplingSettingsFrom.ExtraArgs);
+            }
             ArgsArray = argsList.ToArray();
             return ArgsArray;
         }


### PR DESCRIPTION
Remove `--` from generated `wperf` command when there's no target or extra arguments

![image](https://github.com/user-attachments/assets/4149b600-2bb2-438c-9090-6dcbe80e6b33)
![image](https://github.com/user-attachments/assets/50482ec5-8fbc-4dfc-9975-e3d210ea7283)
