### PR TITLE
fix: use core_num for cpu core count

### DIFF
--- a/WindowsPerfGUI/SDK/WperfClient.cs
+++ b/WindowsPerfGUI/SDK/WperfClient.cs
@@ -234,6 +234,11 @@ namespace WindowsPerfGUI.SDK
                     .TestResults.Find(el => el.TestName == "PMU_CTL_QUERY_HW_CFG [total_gpc_num]")
                     ?.Result;
                 WperfDefaults.TotalGPCNum = Convert.ToInt32(gpc_num, 16);
+
+                string core_num = serializedOutput
+                    .TestResults.Find(el => el.TestName == "PMU_CTL_QUERY_HW_CFG [core_num]")
+                    ?.Result;
+                WperfDefaults.CoreNum = Convert.ToInt32(core_num, 16);
             }
             catch (Exception e)
             {

--- a/WindowsPerfGUI/ToolWindows/SamplingSetting/CpuCores.cs
+++ b/WindowsPerfGUI/ToolWindows/SamplingSetting/CpuCores.cs
@@ -30,6 +30,8 @@
 
 using System.Collections.Generic;
 using WindowsPerfGUI.Resources.Locals;
+using WindowsPerfGUI.SDK.WperfOutputs;
+using WindowsPerfGUI.Utils;
 
 namespace WindowsPerfGUI.ToolWindows.SamplingSetting
 {
@@ -54,13 +56,19 @@ namespace WindowsPerfGUI.ToolWindows.SamplingSetting
         {
             if (numberOfAvailableCores > 0)
                 return CpuCoreList;
-            foreach (
-                var item in new System.Management.ManagementObjectSearcher(
-                    "Select * from Win32_Processor"
-                ).Get()
-            )
+
+            if (WperfDefaults.CoreNum != null)
+                numberOfAvailableCores = (int)WperfDefaults.CoreNum;
+            else
             {
-                numberOfAvailableCores += int.Parse(item["NumberOfCores"].ToString());
+                foreach (
+                    var item in new System.Management.ManagementObjectSearcher(
+                        "Select * from Win32_Processor"
+                    ).Get()
+                )
+                {
+                    numberOfAvailableCores = int.Parse(item["NumberOfCores"].ToString());
+                }
             }
             CreateCpuCoreList();
             return CpuCoreList;

--- a/WindowsPerfGUI/Utils/WperfDefaults.cs
+++ b/WindowsPerfGUI/Utils/WperfDefaults.cs
@@ -38,6 +38,7 @@ namespace WindowsPerfGUI.Utils
 #nullable enable
         public static string? Frequency;
         public static int? TotalGPCNum;
+        public static int? CoreNum = null;
 
 #nullable disable
 


### PR DESCRIPTION
Read cpu core count from `PMU_CTL_QUERY_HW_CFG [core_num]`.
Keep the old implementation as a fallback.