### PR TITLE
Fixing error while trying to read from inaccessible path

### DIFF
--- a/WindowsPerfGUI/Utils/SDK/ProcessRunner.cs
+++ b/WindowsPerfGUI/Utils/SDK/ProcessRunner.cs
@@ -316,7 +316,6 @@ namespace WindowsPerfGUI.Utils.SDK
         {
             if (_BackgroundProcess != null && !_BackgroundProcess.HasExited)
                 throw new Exception("Process already running");
-            string now = new DateTimeOffset(DateTime.UtcNow).ToUnixTimeMilliseconds().ToString();
             _BackgroundProcess = new Process()
             {
                 StartInfo =

--- a/WindowsPerfGUI/Utils/SDK/ProcessRunner.cs
+++ b/WindowsPerfGUI/Utils/SDK/ProcessRunner.cs
@@ -316,6 +316,7 @@ namespace WindowsPerfGUI.Utils.SDK
         {
             if (_BackgroundProcess != null && !_BackgroundProcess.HasExited)
                 throw new Exception("Process already running");
+            string now = new DateTimeOffset(DateTime.UtcNow).ToUnixTimeMilliseconds().ToString();
             _BackgroundProcess = new Process()
             {
                 StartInfo =
@@ -326,6 +327,10 @@ namespace WindowsPerfGUI.Utils.SDK
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             RedirectStandardInput = true,
+            WorkingDirectory = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                    "wperf-cwd-" + now
+                ),
             FileName = _Path,
             Arguments = string.Join(" ", args)
         },

--- a/WindowsPerfGUI/Utils/SDK/ProcessRunner.cs
+++ b/WindowsPerfGUI/Utils/SDK/ProcessRunner.cs
@@ -327,10 +327,7 @@ namespace WindowsPerfGUI.Utils.SDK
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             RedirectStandardInput = true,
-            WorkingDirectory = System.IO.Path.Combine(
-                System.IO.Path.GetTempPath(),
-                    "wperf-cwd-" + now
-                ),
+            WorkingDirectory = System.IO.Path.GetTempPath(),
             FileName = _Path,
             Arguments = string.Join(" ", args)
         },


### PR DESCRIPTION
This pull request includes a small but important change to the `WindowsPerfGUI/Utils/SDK/ProcessRunner.cs` file. The change sets the working directory for the process to the system's temporary path, which ensures that the process runs in a temporary directory.

* [`WindowsPerfGUI/Utils/SDK/ProcessRunner.cs`](diffhunk://#diff-2281f80d259e555b3a9411085105ff1df74df7b83522b4c2b8b776bc51985031R329): Added `WorkingDirectory` property to the process initialization to set it to `System.IO.Path.GetTempPath()`.

This bug is now fixed:
![image (27)](https://github.com/user-attachments/assets/f437f29c-89a1-4229-8af8-1307eb619fc1)
